### PR TITLE
fix: make config appear when there is no local config and fix closing with Enter

### DIFF
--- a/headlines/src/lib.rs
+++ b/headlines/src/lib.rs
@@ -25,7 +25,7 @@ impl App for Headlines {
             return;
         }
 
-        if self.toggle_config || !self.api_key_initialized {
+        if self.toggle_config {
             self.render_config(ctx);
         } else {
             self.preload_articles();


### PR DESCRIPTION
`toggle_config` is initialized to false, and then passed to `.open(toggle_config)`, so the config does not appear.

This change also fixes closing the config window when the user press Enter, see:
https://github.com/emilk/egui/issues/805#issuecomment-1479864586